### PR TITLE
2-sep037

### DIFF
--- a/sep037/BFS/BOJ_11725.swift
+++ b/sep037/BFS/BOJ_11725.swift
@@ -1,0 +1,41 @@
+//
+//  main.swift
+//  11725
+//
+//  Created by Seungeun Park on 4/10/25.
+//
+
+import Foundation
+
+let N = Int(readLine()!)!
+
+var graph = Array(repeating: [Int](), count: N+1)
+var parent = Array(repeating:0, count: N+1)
+var visited = Array(repeating: false, count: N+1)
+
+for _ in 0..<N-1 {
+    let edge = readLine()!.split(separator: " ").map {Int($0)!}
+    
+    let a = edge[0]
+    let b = edge[1]
+    
+    graph[a].append(b)
+    graph[b].append(a)
+}
+
+func dfs(_ currentnode : Int){
+    visited[currentnode] = true
+    
+    for next in graph[currentnode] {
+        if !visited[next] {
+            parent[next] = currentnode
+            dfs(next)
+        }
+    }
+}
+
+dfs(1)
+
+for i in 2...N {
+    print(parent[i])
+}


### PR DESCRIPTION
## 🔗 문제 링크
[트리의 부모 찾기](https://www.acmicpc.net/problem/11725)

<img width="925" alt="스크린샷 2025-04-11 22 45 27" src="https://github.com/user-attachments/assets/7fe0fcea-850d-4ae7-9cfc-df7be9dcc520" />


## ✔️ 소요된 시간
30분 

## ✨ 수도 코드
문제를 살짝 요약해보자면
루트 없는 트리 -> 무방향 그래프 (간선 정보만 존재)
루트는 1로 지정
각 노드의 부모 노드 번호 출력 !

![IMG_FA1FD7D84E78-1](https://github.com/user-attachments/assets/4e944962-df6e-4f48-b46b-2c404a6d1a05)

1. 간선 정보를 바탕으로 인접 리스트를 생성하고

2. 방문 기록을 담을 visited 배열과 부모 정보를 담을 배열을 선언했습니당

3. DFS 함수로 현재 연결된 노드 중
      - 아직 방문하지 않은 노드라면
             - 부모 노드 저장
             - 재귀적으로 다음 노드 탐색
             
4. 1번 루트 노드는 부모가 없으므로 제외하고 2번부터 N번 노드까지 부모를 출력했어요 !
      




## 📚 새롭게 알게된 내용
DFS는 재귀적으로 계속 깊이 들어가기 때문에 이미 방문한 노드에 방문 처리를 하는 습관을 꼭 들여야 겠다고 생각했어요

근데 제가 문제를 많이 안 풀어봐서 모르는데 노드는 거의 1부터 시작하나요 ? 여기서는 루트 노드가 1부터라 납득은 했는데 다른 문제들도 1부터인지 궁금해요 + 문제마다 다른지 .. ?
