### PR TITLE
4-giljihun

### DIFF
--- a/giljihun/README.md
+++ b/giljihun/README.md
@@ -5,4 +5,5 @@
 | 1차시 | 2025.03.30 |  DP  | [1로 만들기](https://www.acmicpc.net/problem/1463)|https://github.com/AlgoLeadMe/AlgoLeadMe-14/pull/4|
 | 2차시 | 2025.04.08 |  DP  | [동전 1](https://www.acmicpc.net/problem/2293)|https://github.com/AlgoLeadMe/AlgoLeadMe-14/pull/8|
 | 3차시 | 2025.04.30 |  문자열  | [IOIOI](https://www.acmicpc.net/problem/5525)|https://github.com/AlgoLeadMe/AlgoLeadMe-14/pull/15|
+| 4차시 | 2025.04.30 |  구현  | [킹](https://www.acmicpc.net/problem/1063)|https://github.com/AlgoLeadMe/AlgoLeadMe-14/pull/23|
 ---

--- a/giljihun/구현/[BOJ] 킹.swift
+++ b/giljihun/구현/[BOJ] 킹.swift
@@ -1,0 +1,81 @@
+/* MARK: - SOLUTION
+ 
+ 1. 8x8 체스판 만들기
+ 2. 컨트롤러 정의
+ 3. 이동 로직
+ 4. 돌을 밀치는 로직
+
+ 핵심 구현은.. 알파벳 -> 좌표 변환
+ 
+ 아스키 코드 쓰면될듯
+ 근데 어케 변환하지
+ 
+ */
+import Foundation
+
+// MARK: - Input & 이동 로직
+guard let N = readLine(),
+      N.components(separatedBy: " ").count >= 3 else { exit(0) }
+let firstPositionOfKing = N.components(separatedBy: " ")[0]
+let firstPositionOfStone = N.components(separatedBy: " ")[1]
+
+// let movingCnt = Int(N.components(separatedBy: " ")[2])
+guard let movingCnt = Int(N.components(separatedBy: " ")[2]) else { exit(0) }
+
+var chessBoard = Array(repeating: Array(repeating: ".", count: 8), count: 8)
+
+let direction: [String: (dx: Int, dy: Int)] = [
+    "R": (1, 0), "L": (-1, 0),
+    "B": (0, 1), "T": (0, -1),
+    "RT": (1, -1), "LT": (-1, -1),
+    "RB": (1, 1), "LB": (-1, 1)
+]
+
+// 초기 위치로 초기화! (x, y) 형태로 만들자
+var posOfKing = toRealCoordinate(firstPositionOfKing)
+var posOfStone = toRealCoordinate(firstPositionOfStone)
+
+// 이동 로직
+for _ in 0..<movingCnt {
+    guard let command = readLine(),
+          // 근데 잘못된 커맨드가 들어오면? 문제 조건엔 없네.
+          let moving = direction[command] else { exit(0) }
+
+    let nextPosOfKing = (posOfKing.0 + moving.dx, posOfKing.1 + moving.dy)
+
+    // 다음 킹의 위치가 체스판 영역에 있는지
+    if (0..<8).contains(nextPosOfKing.0), (0..<8).contains(nextPosOfKing.1) {
+        
+        // 돌이랑 위치가 같아진다면
+        if nextPosOfKing == posOfStone {
+            let nextPosOfStone = (posOfStone.0 + moving.dx, posOfStone.1 + moving.dy)
+            
+            // 다음 돌의 위치가 체스판 영역에 있는지
+            if (0..<8).contains(nextPosOfStone.0), (0..<8).contains(nextPosOfStone.1) {
+                posOfKing = nextPosOfKing
+                posOfStone = nextPosOfStone
+            }
+        } else {
+            posOfKing = nextPosOfKing
+        }
+    }
+}
+
+print(toChessCoordinate(from: posOfKing))
+print(toChessCoordinate(from: posOfStone))
+
+// MARK: - Functions
+// asciiValue: 문자 → 숫자 (ex. ‘A’ → 65)
+// UnicodeScalar: 숫자 → 문자 (ex. 65 → ‘A’)
+
+func toRealCoordinate(_ pos: String) -> (Int, Int) {
+    let x = Int(pos.first!.asciiValue! - 65)
+    let y = 8 - Int(String(pos.last!))!
+    return (x, y)
+}
+
+func toChessCoordinate(from position: (Int, Int)) -> String {
+    let x = String(UnicodeScalar(position.0 + 65)!)
+    let y = String(8 - position.1)
+    return x + y
+}


### PR DESCRIPTION
## 🔗 문제 링크
### [킹](https://www.acmicpc.net/problem/1063)
![image](https://github.com/user-attachments/assets/91e8f601-31d9-44be-86fd-365e3809331d)



## ✔️ 소요된 시간
1h

## ✨ 수도 코드

> 구현 + 시뮬 문제는 아직 폴더가 없길래 정석적인 문제 찾아서 하나 풀어봤습니다!

![image](https://github.com/user-attachments/assets/7f981e0e-0f33-44d7-afe6-170617577b71)

![image](https://github.com/user-attachments/assets/269d9705-c4a1-4735-ac94-cd1c2cc97202)


### 접근
1. ~~8x8 체스판 만들기~~ -> 실제 구현중에 버려졌씁니다.
2. 이동 컨트롤러 정의 (dx, dy)
3. 이동 로직 정의
4. 돌을 밀치는 로직 정의

### 핵심 구현 대상
본 문제의 핵심은 구현중에서도 
**"알파벳 -> 좌표" 변환** 을 잘 구현하는 문제인거같습니다.

왜냐면, 
1. 실제 코테에서 **아스키/스칼라 변환** 이 잘 기억이 안날거같아서 그렇게 느꼈고.
2. 생각보다 보드 게임/아스키변환 문제가 생각보다 자주 보이는 것 같습니다.

실제 함수분리도 아래처럼 컨버터 구현만 했는데요!

```swift
// MARK: - Functions
// asciiValue: 문자 → 숫자 (ex. ‘A’ → 65)
// UnicodeScalar: 숫자 → 문자 (ex. 65 → ‘A’)

func toRealCoordinate(_ pos: String) -> (Int, Int) {
    let x = Int(pos.first!.asciiValue! - 65)
    let y = 8 - Int(String(pos.last!))!
    return (x, y)
}

func toChessCoordinate(from position: (Int, Int)) -> String {
    let x = String(UnicodeScalar(position.0 + 65)!)
    let y = String(8 - position.1)
    return x + y
}
```
> **asciiValue** 는 문자 → 숫자로 변환할 때 사용합니다.
예: 'A'.asciiValue! == 65 → 'A' → 0으로 만들고 싶으면 - 65

> **UnicodeScalar** 는 숫자 → 문자로 변환할 때 사용합니다.
예: UnicodeScalar(65)! == "A" → 0 → 'A'로 만들고 싶으면 + 65

이 두개는 익혀두면 분명 효용이 있어보입니다!

### Int() 초기화는 항상 옵셔널(Int?)을 뱉는다.

```swift
// let movingCnt = Int(N.components(separatedBy: " ")[2])
guard let movingCnt = Int(N.components(separatedBy: " ")[2]) else { exit(0) }
```

본 코드를 보면 기존에 위처럼 작성했다가 guard let으로 감싼 부분이 있어요. 
이유가 왤까요?

```swift
// 이동 로직
for _ in 0..<movingCnt {
```
이유는 movingCnt를 활용하는 for문에 있습니다. 
guard let으로 옵셔널을 언래핑 해주지 않으면, movingCnt에는 옵셔널 Int가 들어가기 때문에 for문의 조건으로 넣을 수가 없지요.

**Int()는 변환 실패 가능성 때문에 항상 Int? 타입의 값을 반환합니다.**

### 후기
다른 구현은 일반적인 구현이라 따로 적진 않겠습니다. 
코드보고 궁금한거 여쭤봐주세요 !! ~