### PR TITLE
5-giljihun

### DIFF
--- a/giljihun/BFS/[BOJ] 소트 게임.swift
+++ b/giljihun/BFS/[BOJ] 소트 게임.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/*
+ 
+ 1~N까지 정수로 이루어진 N자리의 순열.
+ 
+ K가 주어짐 ->
+ 어떤 수를 뒤집음 ->
+ 그 수부터 오른쪽으로 K개의 수를 뒤집음.
+ 
+ [5 4 3 2 1], K = 3 ->
+ 어떤 수 = 4 ->
+ [5 2 4 3 1]
+ 
+ 5 4 3 2 1
+ 5 4 3 2 1
+ 5 4 1 2 3
+ 1 4 5 2 3
+ 1 2 5 4 3
+ 1 2 3 4 5
+ -> 5번..
+ -> 각 상태를 체크하고 오름차순과 맞는지 계속 봐야함.
+ 
+ 
+ 2 ≤ K ≤ N ≤ 8
+ 
+ --------------------
+ 
+ 입력으로 들어온 수를 오름차순으로 sort하고싶음!
+ 근데 최소한의 turn으로.
+ 몇 번의 turn이 필요?
+ 
+ --------------------
+ 
+ 1. turn을 지나오며 오름차순 배열과 같은 지 체크한다?
+ 2. 근데 오름차순으로 만들 수 없는 경우는? -> 끝까지 오름차순 배열이 안나올때?
+
+ */
+
+// 입력부
+guard let input = readLine()?.split(separator: " ").compactMap({ Int($0) }),
+          input.count == 2 else { exit(0) }
+let (N, K) = (input[0], input[1])
+
+guard let initialArr = readLine()?.split(separator: " ").compactMap({ Int($0) }),
+      initialArr.count > 0 else { exit(0) }
+      
+// 목표 타겟
+let targetArr = initialArr.sorted()
+
+
+// BFS
+var searchQueue: [([Int], Int)] = [(initialArr, 0)]
+var visitedArr: Set<[Int]> = [initialArr]
+
+while !searchQueue.isEmpty {
+    let (currentArr, turnCnt) = searchQueue.removeFirst()
+    
+    if currentArr == targetArr {
+        print(turnCnt)
+        exit(0)
+    }
+    
+    for i in 0..<(N - K + 1) {
+        var nextArr = currentArr
+        nextArr[i..<i+K].reverse()
+        
+        if !visitedArr.contains(nextArr) {
+            visitedArr.insert(nextArr)
+            searchQueue.append((nextArr, turnCnt + 1))
+        }
+    }
+}
+
+print(-1)

--- a/giljihun/README.md
+++ b/giljihun/README.md
@@ -6,4 +6,5 @@
 | 2차시 | 2025.04.08 |  DP  | [동전 1](https://www.acmicpc.net/problem/2293)|https://github.com/AlgoLeadMe/AlgoLeadMe-14/pull/8|
 | 3차시 | 2025.04.30 |  문자열  | [IOIOI](https://www.acmicpc.net/problem/5525)|https://github.com/AlgoLeadMe/AlgoLeadMe-14/pull/15|
 | 4차시 | 2025.04.30 |  구현  | [킹](https://www.acmicpc.net/problem/1063)|https://github.com/AlgoLeadMe/AlgoLeadMe-14/pull/23|
+| 5차시 | 2025.05.23 |  BFS  | [킹](https://www.acmicpc.net/problem/1327)|https://github.com/AlgoLeadMe/AlgoLeadMe-14/pull/26|
 ---


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
### [소트 게임](https://www.acmicpc.net/problem/1327)
![image](https://github.com/user-attachments/assets/cb6ed98e-6d8b-42a8-b6a9-bb03a63c3cef)
> 저퀄 길송합니다.
## ✔️ 소요된 시간
1h 

## ✨ 수도 코드

문제를 보고, 바로 dfs 혹은 bfs로 풀어야겠다고 생각이 나질 않았습니다.
그런데, 입력에 대해 변화를 직접 하나하나 나열해보니
각 순열의 상태가 1번의 turn을 갖고 바뀐다는 점에서
각 상태가 간선으로 연결된 노드와 같더군요. (그래프의 노드처럼 서로 연결되는 구조!)

> 한마디로 초기 상태에서 최종라스트파이널상태인 오름차순 상태로 가는 최저 turn의 수.
곧 최단 거리라는 사고로 연결이 되네요!
추가적으로,  문제 접근 후 알고리즘을 선택하는 영역에서 C3에서 배운 Think Aloud 기법이 나름 도움이 되더라고요!

### BFS 선택 근거
현재 상태 -> 다음 상태를 찾아가는 상태 기반 문제의 구조 상,
가까운 상태먼저 다 체크하는 BFS가 자연스럽다고 판단했습니다. 

특히, **최단 경로** 를 찾는 문제에선 가능한 상태의 수 (여기선 8! = 40320 이죵)를 봐야합니다.
최단경로는 bfs로 무조건 찾기에, 성능이슈만 확인하면 되니까요!

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

### 1. DFS, BFS 선택 기준을 문제 구조로부터 파악하기
가끔 최단 경로, 거리를 품에 있어서 두가지 모두 사용되는 경우도 있고
결국 **선택**을 하게 되는데요. 
물론 둘다 사용해보거나 할줄 알면 확실하겠지만, 
결국 그냥 외우는게 아니라 문제의 구조로부터 자연스럽게 도출되어야 한다는 걸 느꼈습니다.

#### DFS는 언제 유리한가?
> “모든 경우를 다 봐야 하는 문제”, 즉 완전 탐색 문제에 적합

- 모든 조합/순열을 다 따져야 하는 문제
ex: 백트래킹, 부분집합 구하기, 탐색 깊이에 따라 가지치기할 때

- 특정 조건을 만족하는 모든 해를 찾아야 할 때
ex: 특정 경로들 출력, 특정 조건을 만족하는 조합 개수 세기 등

목표가 **최적 경로** 가 아니라 **모든 경우 탐색** 일 때 유리하겠네요.

#### BFS는 언제 유리한가?
> “목표 상태에 가장 빨리 도달하는 방법”, 즉 최단 거리/최소 횟수 문제에 적합

- 최단 거리, 최소 연산, 최소 시간 등
ex: 미로 최단 경로, 퍼즐 문제, 숫자 만들기, 단어 변환 등

- 상태 전이가 가능한 구조에서 가장 먼저 도달한 것이 정답인 문제

거리 단위로 상태를 확장하며 탐색해야할 때 유리하겠네요.
먼저 도달한 해 = 정답 (무조건 최단 경로)

--- 

위 내용 기준으로 다시 문제를 보면, 
이 문제는 모든 경우를 볼 필요 없죠? (그건 최악의 상황)
처음으로 오름차순 상태에 도달한 순간이 바로 정답이니까요!
그러니, BFS가 적합!

생각의 힘을 확장하는 게, 알고리즘 공부같다고 느끼는 문제 회고였습니다!
